### PR TITLE
Wrap main() function with NONIUS_RUNNER macro

### DIFF
--- a/include/nonius/main.h++
+++ b/include/nonius/main.h++
@@ -177,9 +177,11 @@ namespace nonius {
     }
 }
 
+#ifdef NONIUS_RUNNER
 int main(int argc, char** argv) {
     return nonius::main(argc, argv);
 }
+#endif // NONIUS_RUNNER
 
 #endif // NONIUS_MAIN_HPP
 


### PR DESCRIPTION
In this case we can write own main() function. In my case I write benchmarks for Qt based application,
so initialize QCoreApplication first and return `QCoreApplication::instance()->exit(nonius::main(argc, argv));` as exit code.
